### PR TITLE
Fixed "Get-AdFilePaste" function to have logfile param

### DIFF
--- a/anydesk.ps1
+++ b/anydesk.ps1
@@ -664,6 +664,11 @@ function Get-ADFilePaste{
         Parses C:\ad_svc.trace and returns the applicable data
 #>
 
+    [CmdletBinding()]
+    param(
+        $logfile
+    )    
+
     $log = Get-Content $logfile
     $lines = $log | Select-String -Pattern 'ole.files - Finished file paste operation'
     $obj = @()


### PR DESCRIPTION
Was testing code and noticed the Get-ADFilePaste function didn't have the param set correctly.